### PR TITLE
Handle 'index out of range' errors

### DIFF
--- a/autoload/istanbul.py
+++ b/autoload/istanbul.py
@@ -37,14 +37,17 @@ def sign_covered_lines():
             branchMap = field['branchMap']
             for i, br in branchMap.items():
                 line = br['line']
-                if field['b'][i][0] < 1 and field['b'][i][1] > 0:
-                    sign_place = "sign place {} line={} name={} buffer={}"\
-                        .format(line, line, 'branch_true', buffernr)
-                    vim.command(sign_place)
-                if field['b'][i][1] < 1 and field['b'][i][0] > 0:
-                    sign_place = "sign place {} line={} name={} buffer={}"\
-                        .format(line, line, 'branch_false', buffernr)
-                    vim.command(sign_place)
+                try:
+                    if field['b'][i][0] < 1 and field['b'][i][1] > 0:
+                        sign_place = "sign place {} line={} name={} buffer={}"\
+                            .format(line, line, 'branch_true', buffernr)
+                        vim.command(sign_place)
+                    if field['b'][i][1] < 1 and field['b'][i][0] > 0:
+                        sign_place = "sign place {} line={} name={} buffer={}"\
+                            .format(line, line, 'branch_false', buffernr)
+                        vim.command(sign_place)
+                except:
+                    continue
 
             fn_map = field['fnMap']
             for i,fn in fn_map.items():


### PR DESCRIPTION
Occasionally there will be indexes in branchMap.items that are not in the field.b list.

This ignores that error and soldiers on silently.  A better fix might be to figure out why Istanbul does this, but whatever.  Ignoring it seems to be fine.